### PR TITLE
Get rid of unirest

### DIFF
--- a/is_available.gemspec
+++ b/is_available.gemspec
@@ -19,7 +19,6 @@ Gem::Specification.new do |spec|
   spec.executable    = "is_available"
   spec.require_paths = ['lib']
   
-  spec.add_dependency "unirest"
   spec.add_dependency "command_lion"
 
   spec.add_development_dependency "bundler", "~> 1.15"

--- a/lib/is_available.rb
+++ b/lib/is_available.rb
@@ -1,4 +1,4 @@
-require "unirest"
+require "net/http"
 require "resolv"
 require "is_available/version"
 
@@ -6,7 +6,7 @@ module IsAvailable
   WHOIS_DOT_COM_LINK = "https://www.whois.com/whois/"
   
   def self.registered?(domain)
-    Unirest.get(WHOIS_DOT_COM_LINK+domain).body.include?("Registrar")
+    Net::HTTP.get_response(URI.parse(WHOIS_DOT_COM_LINK+domain)).body.include?("Registrar")
   end
 
   def self.resolvable?(domain)


### PR DESCRIPTION
I personally don't like unirest. Also, installation of 'is_available' is faster without it.
There is a problem here though and I'm not sure if this is just for me or everyone else running Windows. The problem is that OpenSSL throws this error:
`OpenSSL::SSL::SSLError: SSL_connect returned=1 errno=0 state=error: certificate verify failed`
when HTTPS is used. 

Other than that, it works fine on my Ubuntu installation.